### PR TITLE
Determine the correct IP to listen on.

### DIFF
--- a/lib/viera_play/player.rb
+++ b/lib/viera_play/player.rb
@@ -1,9 +1,10 @@
 module VieraPlay
   class Player
     def initialize(opts)
-      @tv = TV.new(opts.fetch(:tv_control_url))
+      uri = URI(opts.fetch(:tv_control_url))
+      @tv = TV.new(uri)
       @file_path = opts.fetch(:file_path)
-      @server = SingleFileServer.new(file_path, opts.fetch(:additional_mime_types, {}))
+      @server = SingleFileServer.new(file_path, opts.fetch(:additional_mime_types, {}), uri.host)
     end
 
     def call

--- a/lib/viera_play/single_file_server.rb
+++ b/lib/viera_play/single_file_server.rb
@@ -3,9 +3,10 @@ require "socket"
 
 module VieraPlay
   class SingleFileServer
-    def initialize(file_path, additional_mime_types={})
+    def initialize(file_path, additional_mime_types={}, source_ip = '8.8.8.8')
       @file_path = file_path
       @additional_mime_types = FORMATS.merge(additional_mime_types)
+      @source_ip = source_ip
     end
 
     def start
@@ -21,7 +22,7 @@ module VieraPlay
     end
 
     private
-    attr_reader :file_path, :additional_mime_types
+    attr_reader :file_path, :additional_mime_types, :source_ip
 
     FORMATS = {
       ["mkv", "mp4", "wmv", "avi", "mov"] => "video/x-msvideo",
@@ -52,7 +53,7 @@ module VieraPlay
 
     def local_ip
       @local_ip ||= UDPSocket.open do |s|
-        s.connect '8.8.8.8', 1
+        s.connect source_ip, 1
         s.addr.last
       end
     end

--- a/lib/viera_play/soapy.rb
+++ b/lib/viera_play/soapy.rb
@@ -4,7 +4,7 @@ require "uri"
 module VieraPlay
   class Soapy
     def initialize(opts={})
-      @endpoint = URI.parse(opts.fetch(:endpoint))
+      @endpoint = URI(opts.fetch(:endpoint))
       @namespace = opts.fetch(:namespace)
       @default_request_args = opts.fetch(:default_request_args, {})
     end


### PR DESCRIPTION
With multiple interfaces, we need to pick the one the TV is connected to. As
such we can use the IP for the TV control URL to make a better selection than
just the public interface.